### PR TITLE
feat: create tests and docker-compose

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-        - name: Lint
+      - name: Lint
         run: docker compose run --rm lint
 
       - name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-        #- name: Lint
-        #run: docker compose run --rm lint
+        - name: Lint
+        run: docker compose run --rm lint
 
       - name: Test
         run: docker compose run --rm tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+name: Lint and Test
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+        #- name: Lint
+        #run: docker compose run --rm lint
+
+      - name: Test
+        run: docker compose run --rm tests

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Add the following to your `pipeline.yml`:
 
 ```yml
 steps: 
-  ...
-  plugins:
-    - cultureamp/trufflehog
+  - plugins:
+    - cultureamp/trufflehog:
         trufflehog_uri: trufflesecurity/trufflehog:latest
         image_uri: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TruffleHog Secret Sniffer
+# TruffleHog Buildkite Plugin
 
 This plugin attempts to find secrets within the image using TruffleHog and annotates the build with either a list of files containing secrets or a confirmation that no secrets were found.
 
@@ -9,18 +9,18 @@ Add the following to your `pipeline.yml`:
 ```yml
 steps: 
   - plugins:
-    - cultureamp/trufflehog:
-        trufflehog_uri: trufflesecurity/trufflehog:latest
-        image_uri: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest
+      - cultureamp/trufflehog#v1.0.0:
+          trufflehog-image-uri: 'trufflesecurity/trufflehog:latest'
+          image-uri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest'
 ```
 
 ## Configuration
 
-### `trufflehog_uri` (required)
+### `trufflehog_uri` (required, string)
 
-The Docker URI for the TruffleHog image.
+The Docker URI for the TruffleHog image. 
 
-### `image_uri` (required)
+### `image_uri` (required, string)
 
 The URI of the image to scan for secrets.
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ steps:
 
 ## Configuration
 
-### `trufflehog_uri` (required, string)
+### `trufflehog-image-uri` (optional, string)
 
 The Docker URI for the TruffleHog image. 
 
-### `image_uri` (required, string)
+### `image-uri` (required, string)
 
 The URI of the image to scan for secrets.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# TruffleHog Secret Sniffer
+
+This plugin attempts to find secrets within the image using TruffleHog and annotates the build with either a list of files containing secrets or a confirmation that no secrets were found.
+
+## Example
+
+Add the following to your `pipeline.yml`:
+
+```yml
+steps: 
+  ...
+  plugins:
+    - cultureamp/trufflehog
+        trufflehog_uri: trufflesecurity/trufflehog:latest
+        image_uri: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest
+```
+
+## Configuration
+
+### `trufflehog_uri` (required)
+
+The Docker URI for the TruffleHog image.
+
+### `image_uri` (required)
+
+The URI of the image to scan for secrets.
+
+## Developing
+
+To run the tests:
+
+```shell
+docker-compose run --rm tests
+```
+
+## Contributing
+
+1. Fork the repository
+2. Make the changes
+3. Run the tests
+4. Commit and push the changes
+5. Create a pull request
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  lint:
+    image: buildkite/plugin-linter
+    command: ['--id', 'cultureamp/trufflehog']
+    volumes:
+      - ".:/plugin:ro"
+  tests:
+    image: buildkite/plugin-tester
+    volumes:
+      - ".:/plugin:ro"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,7 +8,7 @@ if [[ -z "${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" ]]; then
     exit 1
 fi
 
-trufflehog_image_version="${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI:trufflesecurity/trufflehog:latest}"
+trufflehog_image_version="${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI:-trufflesecurity/trufflehog:latest}"
 temp_results="/tmp/results.json"
 touch $temp_results
 echo "--- :docker: Pulling images"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,17 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-image="$BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI"
+temp_results="/tmp/results.json"
+touch $temp_results
 echo "--- :docker: Pulling images"
-docker pull trufflesecurity/trufflehog:latest
+docker pull "${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI}"
 echo "--- :docker: Running TruffleHog"
-results="$(docker run --rm -it -v '$PWD:/pwd' trufflesecurity/trufflehog:latest docker --image=${image} --json --only-verified --fail)"
-trufflehog_status=$?
-files = $(echo $results | jq '. | .SourceMetadata.Data.Docker.file')
+docker run --rm -it -v "$PWD:/pwd" "${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI}" docker --image="${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" --json --only-verified | tee "${temp_results}"
+echo "--- :docker: Parsing results"
+files="$(cat $temp_results | jq '. | .SourceMetadata.Data.Docker.file')"
+files_status=$?
 
 # If any findings, annotate the build.
-if [[ $trufflehog_status -ne 0 ]]; then 
+if [[ $files_status -eq 0 ]]; then 
     buildkite-agent annotate --style 'error' "Trufflehog found secrets in the container image:\n $files"
+    exit 1
 else
     buildkite-agent annotate --style 'success' "No secrets detected by TruffleHog."
+    exit 0
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,13 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
-IMAGE="$BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI"
-curl -sSfL -k https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin v3.81.9
-echo "Performing container scan"
-
-results = $(trufflehog docker --image="$IMAGE" --json --only-verified --fail)
+image="$BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI"
+echo "--- :docker: Pulling images"
+docker pull trufflesecurity/trufflehog:latest
+echo "--- :docker: Running TruffleHog"
+results="$(docker run --rm -it -v '$PWD:/pwd' trufflesecurity/trufflehog:latest docker --image=${image} --json --only-verified --fail)"
 trufflehog_status=$?
 files = $(echo $results | jq '. | .SourceMetadata.Data.Docker.file')
 
 # If any findings, annotate the build.
-[ $trufflehog_status -ne 0 ] && buildkite-agent annotate --style 'success' "No secrets detected by TruffleHog." || buildkite-agent annotate --style 'error' "Trufflehog found secrets in the container image: $RESULTS"
+if [[ $trufflehog_status -ne 0 ]]; then 
+    buildkite-agent annotate --style 'error' "Trufflehog found secrets in the container image:\n $files"
+else
+    buildkite-agent annotate --style 'success' "No secrets detected by TruffleHog."
+fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,12 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
+# Fail if the target image is not set
+if [[ -z "${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" ]]; then
+    echo "image-uri is required"
+    buildkite-agent annotate --style 'error' "TruffleHog: `image-uri` is required"
+    exit 1
+fi
+
+trufflehog_image_version="${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI:trufflesecurity/trufflehog:latest}"
 temp_results="/tmp/results.json"
 touch $temp_results
 echo "--- :docker: Pulling images"
-docker pull "${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI}"
+docker pull "${trufflehog_image_version}" 
 echo "--- :docker: Running TruffleHog"
-docker run --rm -it -v "$PWD:/pwd" "${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI}" docker --image="${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" --json --only-verified | tee "${temp_results}"
+docker run --rm -it -v "$PWD:/pwd" "${trufflehog_image_version}" docker --image="${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" --json --only-verified | tee "${temp_results}"
 echo "--- :docker: Parsing results"
 files="$(cat $temp_results | jq '. | .SourceMetadata.Data.Docker.file')"
 files_status=$?

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -2,9 +2,8 @@
 set -euo pipefail
 
 # Fail if the target image is not set
-if [[ -z "${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" ]]; then
-    echo "image-uri is required"
-    buildkite-agent annotate --style 'error' "TruffleHog: `image-uri` is required"
+if [[ -z "${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI:-}" ]]; then
+    echo "trufflehog plugin: image-uri is a required parameter" 1>&2
     exit 1
 fi
 
@@ -12,7 +11,7 @@ trufflehog_image_version="${BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI:-tr
 temp_results="/tmp/results.json"
 touch $temp_results
 echo "--- :docker: Pulling images"
-docker pull "${trufflehog_image_version}" 
+docker pull "${trufflehog_image_version}"
 echo "--- :docker: Running TruffleHog"
 docker run --rm -it -v "$PWD:/pwd" "${trufflehog_image_version}" docker --image="${BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI}" --json --only-verified | tee "${temp_results}"
 echo "--- :docker: Parsing results"
@@ -20,7 +19,7 @@ files="$(cat $temp_results | jq '. | .SourceMetadata.Data.Docker.file')"
 files_status=$?
 
 # If any findings, annotate the build.
-if [[ $files_status -eq 0 ]]; then 
+if [[ $files_status -eq 0 ]]; then
     buildkite-agent annotate --style 'error' "Trufflehog found secrets in the container image:\n $files"
     exit 1
 else

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,7 @@ author: https://github.com/liamstevens
 requirements: []
 configuration:
   properties:
-    trufflhog_uri:
+    trufflehog_image_uri:
       type: string
       title: TruffleHog URI
       description: The URI of the TruffleHog image.

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,12 +4,10 @@ author: https://github.com/liamstevens
 requirements: []
 configuration:
   properties:
-    trufflehog_image_uri:
+    trufflehog-image-uri:
       type: string
-      title: TruffleHog URI
       description: The URI of the TruffleHog image.
-    image_uri:
+    image-uri:
       type: string
-      title: Image URI
       description: The URI of the container image to scan.
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,6 +4,10 @@ author: https://github.com/liamstevens
 requirements: []
 configuration:
   properties:
+    trufflhog_uri:
+      type: string
+      title: TruffleHog URI
+      description: The URI of the TruffleHog image.
     image_uri:
       type: string
       title: Image URI

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,30 +1,30 @@
 #!/usr/bin/env bats
 
 load "$BATS_PLUGIN_PATH/load.bash"
-load helpers/mocks/stub
 
-@test "Scans for leaked secrets" {
+# Uncomment the following line to debug stub failures
+#export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+@test "Trufflehog should find secrets" {
     export BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI="liamstevensca/truffletest:latest"
-    export BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_URI="trufflesecurity/trufflehog:latest"
+    export BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI="trufflesecurity/trufflehog:latest"
+    export sample_detection='{"SourceMetadata":{"Data":{"Docker":{"file":"image-metadata:history:16:created-by","image":"liamstevensca/truffletest","tag":"latest"}}},"SourceID":1,"SourceType":4,"SourceName":"trufflehog - docker","DetectorType":8,"DetectorName":"Github","DecoderName":"PLAIN","Verified":true,"Raw":"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","RawV2":"","Redacted":"","ExtraData":{"account_type":"User","expiry":"2024-09-03 09:50:09 +1000","location":"Australia","name":"Liam Stevens","rotation_guide":"https://howtorotate.com/docs/tutorials/github/","url":"https://github.com/liamstevens","username":"liamstevens","version":"2"},"StructuredData":null}'
 
-    #stub buildkite-agent 'annotate "Found a secret" : echo Annotation created'
+    stub buildkite-agent \
+    'annotate --style error * : echo "Got error annotation"' \
+    'annotate --style success * : echo "Got success annotation"' \
 
     #unstub buildkite-agent
 
     stub docker \
         'pull * : echo $@'\
-        'run * : echo {}'\
-        'run * : echo {"SourceMetadata":{"Data":{"Docker":{"file":"image-metadata:history:16:created-by","image":"liamstevensca/truffletest","tag":"latest"}}},"SourceID":1,"SourceType":4,"SourceName":"trufflehog - docker","DetectorType":8,"DetectorName":"Github","DecoderName":"PLAIN","Verified":true,"Raw":"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","RawV2":"","Redacted":"","ExtraData":{"account_type":"User","expiry":"2024-09-03 09:50:09 +1000","location":"Australia","name":"Liam Stevens","rotation_guide":"https://howtorotate.com/docs/tutorials/github/","url":"https://github.com/liamstevens","username":"liamstevens","version":"2"},"StructuredData":null}'
-
-
+        'run --rm -it -v * $BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI docker --image=$BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI * * : echo "$sample_detection"'
 
 
     run "$PWD/hooks/post-command"
 
     unstub docker
 
-    assert_success
-    assert_output --partial "Found a secret"
-    assert_output --partial "Annotation created"
+    assert_failure
+    assert_output --partial "Got error annotation"
 
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,17 +1,30 @@
 #!/usr/bin/env bats
 
 load "$BATS_PLUGIN_PATH/load.bash"
+load helpers/mocks/stub
 
 @test "Scans for leaked secrets" {
     export BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI="liamstevensca/truffletest:latest"
+    export BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_URI="trufflesecurity/trufflehog:latest"
 
-    stub buildkite-agent 'annotate "Found a secret" : echo Annotation created'
+    #stub buildkite-agent 'annotate "Found a secret" : echo Annotation created'
+
+    #unstub buildkite-agent
+
+    stub docker \
+        'pull * : echo $@'\
+        'run * : echo {}'\
+        'run * : echo {"SourceMetadata":{"Data":{"Docker":{"file":"image-metadata:history:16:created-by","image":"liamstevensca/truffletest","tag":"latest"}}},"SourceID":1,"SourceType":4,"SourceName":"trufflehog - docker","DetectorType":8,"DetectorName":"Github","DecoderName":"PLAIN","Verified":true,"Raw":"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","RawV2":"","Redacted":"","ExtraData":{"account_type":"User","expiry":"2024-09-03 09:50:09 +1000","location":"Australia","name":"Liam Stevens","rotation_guide":"https://howtorotate.com/docs/tutorials/github/","url":"https://github.com/liamstevens","username":"liamstevens","version":"2"},"StructuredData":null}'
+
+
+
 
     run "$PWD/hooks/post-command"
+
+    unstub docker
 
     assert_success
     assert_output --partial "Found a secret"
     assert_output --partial "Annotation created"
 
-    unstub buildkite-agent
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -4,16 +4,22 @@ load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment the following line to debug stub failures
 #export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+@test "Fail when required parameter not set" {
+    run "$PWD/hooks/post-command"
+
+    assert_failure
+    assert_output --partial "trufflehog plugin: image-uri is a required parameter"
+}
+
 @test "Trufflehog should find secrets" {
     export BUILDKITE_PLUGIN_TRUFFLEHOG_IMAGE_URI="liamstevensca/truffletest:latest"
     export BUILDKITE_PLUGIN_TRUFFLEHOG_TRUFFLEHOG_IMAGE_URI="trufflesecurity/trufflehog:latest"
     export sample_detection='{"SourceMetadata":{"Data":{"Docker":{"file":"image-metadata:history:16:created-by","image":"liamstevensca/truffletest","tag":"latest"}}},"SourceID":1,"SourceType":4,"SourceName":"trufflehog - docker","DetectorType":8,"DetectorName":"Github","DecoderName":"PLAIN","Verified":true,"Raw":"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","RawV2":"","Redacted":"","ExtraData":{"account_type":"User","expiry":"2024-09-03 09:50:09 +1000","location":"Australia","name":"Liam Stevens","rotation_guide":"https://howtorotate.com/docs/tutorials/github/","url":"https://github.com/liamstevens","username":"liamstevens","version":"2"},"StructuredData":null}'
 
     stub buildkite-agent \
-    'annotate --style error * : echo "Got error annotation"' \
-    'annotate --style success * : echo "Got success annotation"' \
-
-    #unstub buildkite-agent
+        'annotate --style error * : echo "Got error annotation"' \
+        'annotate --style success * : echo "Got success annotation"' \
 
     stub docker \
         'pull * : echo $@'\
@@ -23,8 +29,8 @@ load "$BATS_PLUGIN_PATH/load.bash"
     run "$PWD/hooks/post-command"
 
     unstub docker
+    #unstub buildkite-agent
 
     assert_failure
     assert_output --partial "Got error annotation"
-
 }


### PR DESCRIPTION
# What
This PR adds the plugin following feedback and eventual getting `bats` tests to function on it.

# Why
So we can have a functioning plugin to reference and start testing in our pipelines.